### PR TITLE
Add studio sections to homepage

### DIFF
--- a/src/components/landings/StudioSection.tsx
+++ b/src/components/landings/StudioSection.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+
+interface StudioSectionProps {
+  title: string;
+  description: string;
+}
+
+const StudioSection = ({ title, description }: StudioSectionProps) => (
+  <Box component="section" sx={{ py: 8, textAlign: "center" }}>
+    <Typography variant="h4" component="h2" gutterBottom>
+      {title}
+    </Typography>
+    <Typography variant="body1">{description}</Typography>
+  </Box>
+);
+
+export default StudioSection;

--- a/src/templates/home.tsx
+++ b/src/templates/home.tsx
@@ -15,6 +15,7 @@ import LandingsFeature from "../components/landings/landings-feature";
 import WithIllustrationFeatures from "../components/landings/WithIllustrationFeatures";
 import { Pricing } from "../components/landings/pricing";
 import Email from "components/landings/email";
+import StudioSection from "../components/landings/StudioSection";
 
 const HomePage = ({ data, location }) => {
   const { markdownRemark, allArticlesJson } = data;
@@ -46,14 +47,24 @@ const HomePage = ({ data, location }) => {
         />
         
         {/* Core features section */}
-        <CardFeatureBlock 
-          titles={frontmatter.T100} 
-          bodys={frontmatter.B100} 
+        <CardFeatureBlock
+          titles={frontmatter.T100}
+          bodys={frontmatter.B100}
         />
-        
+
+        <StudioSection
+          title="Speech Studio"
+          description="Generate and refine natural-sounding speech with powerful AI tools."
+        />
+
+        <StudioSection
+          title="Content Studio"
+          description="Create, edit and organize written content effortlessly."
+        />
+
         {/* FAQ section */}
-        {/* <AccordionBlock 
-          questions={faqPairs} 
+        {/* <AccordionBlock
+          questions={faqPairs}
         /> */}
         
         {/* Disabled sections - preserved for future use */}


### PR DESCRIPTION
## Summary
- add reusable `StudioSection` component for simple heading/description sections
- integrate two `StudioSection` blocks on the home page to highlight Speech Studio and Content Studio

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688e1071013883208fb99c47ce82e659